### PR TITLE
nrf_security: Enable when entropy is enabled on nrf71XX

### DIFF
--- a/subsys/nrf_security/Kconfig
+++ b/subsys/nrf_security/Kconfig
@@ -34,8 +34,8 @@ config NRF_SECURITY
 	prompt "Enable nRF Security" if !PSA_PROMPTLESS
 	depends on SOC_FAMILY_NORDIC_NRF
 	default y if BUILD_WITH_TFM
-	# entropy is provided by PSA and NRF_SECURITY on NRF54LX
-	default y if ENTROPY_PSA_CRYPTO_RNG && SOC_SERIES_NRF54LX
+	# entropy is provided by PSA and NRF_SECURITY on NRF54LX and NRF71X
+	default y if ENTROPY_PSA_CRYPTO_RNG && (SOC_SERIES_NRF54LX || SOC_SERIES_NRF71X)
 	select DISABLE_MBEDTLS_BUILTIN if MBEDTLS
 	# NCS does not use TF-M's BL2 bootloader, but uses it's own fork
 	# of MCUBoot instead (CONFIG_BOOTLOADER_MCUBOOT).


### PR DESCRIPTION
Enable nrf_security when entropy is enabled for nRF71XX